### PR TITLE
removing, causes compile errors in linux `unused-but-set-variable`

### DIFF
--- a/src/cmds/detab.c
+++ b/src/cmds/detab.c
@@ -30,12 +30,10 @@ CMDHANDLER(detab)
 	ssize_t l;
 	size_t i,j;
 	int tabstop = 4;
-	int ret = 0;
 
 	/* XXX put support for reading a file instead of stdin here */
 
 	if(argc >= 1) {
-		ret = 1;
 		tabstop = atoi(argv[0]);
 		if(tabstop < 1 || tabstop > 80)
 			tabstop = 4;


### PR DESCRIPTION
requesting to remove unused code, causes compile errors in linux which causes `./env install manifests/developer.manifest`  to fail
